### PR TITLE
Change the default Keep-Alive timeout to 95 seconds

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,14 @@ const server = app.listen(port, () => {
   console.log(`Listening on ${port}`)
 })
 
+// The number of seconds an idle Keep-Alive connection is kept open. This should be greater than the Heroku Router's
+// Keep-Alive idle timeout of 90 seconds:
+// - to ensure that the closing of idle connections is always initiated by the router and not the Node.js server
+// - to prevent a race condition if the router sends a request to the app just as Node.js is closing the connection
+// https://devcenter.heroku.com/articles/http-routing#keepalives
+// https://nodejs.org/api/http.html#serverkeepalivetimeout
+server.keepAliveTimeout = 95 * 1000
+
 process.on('SIGTERM', async () => {
   console.log('SIGTERM signal received: gracefully shutting down')
   if (server) {


### PR DESCRIPTION
For consistency with the timeouts used by other languages:
- https://github.com/heroku/heroku-buildpack-php/pull/823
- https://github.com/heroku/ruby-getting-started/pull/190
- https://github.com/heroku/python-getting-started/pull/263

[W-19261055](https://gus.lightning.force.com/a07EE00002JdM1gYAF)